### PR TITLE
添加目录代理功能,修复排序问题

### DIFF
--- a/host-switch-plus/js/model.js
+++ b/host-switch-plus/js/model.js
@@ -341,6 +341,8 @@
                     var t=info.domain.split(':');
                     port = t[1];
                     script += '}else if(shExpMatch(url,"http://' + info.domain + '/*") || shExpMatch(url,"https://' + info.domain + '/*")){';
+                }else if(info.domain.indexOf('/')!=-1){
+                    script += '}else if(shExpMatch(url,"http://' + info.domain + '/*") || shExpMatch(url,"https://' + info.domain + '/*")){';
                 }else{
                     script += '}else if(host == "' + info.domain + '"){';
                 }

--- a/host-switch-plus/js/model.js
+++ b/host-switch-plus/js/model.js
@@ -131,7 +131,7 @@
                 hosts = {};
             }
             var id = 1 + c;
-            info.status = 0;
+            // info.status = 0;
             info.id = id;
 
             saveData('hosts-count', id);

--- a/host-switch-plus/js/model.js
+++ b/host-switch-plus/js/model.js
@@ -113,7 +113,7 @@
         return result.sort(function(x, y){
                 var a = Number(x.order),
                     b = Number(y.order);
-                return (isNaN(a) ? 1 : a) < (isNaN(b) ? 1 : b);
+                return (isNaN(b) ? 1 : b)-(isNaN(a) ? 1 : a);
             });
     }
 


### PR DESCRIPTION
修复排序问题

添加host时默认为开启状态

添加在某个目录下才开始代理功能,用于单域名前后端服务器分离的情况